### PR TITLE
configure: use AC_CONFIG_FILES() macro

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -54,4 +54,5 @@ fi
 
 AC_SUBST([moduledir])
 
-AC_OUTPUT([Makefile src/Makefile man/Makefile])
+AC_CONFIG_FILES([Makefile src/Makefile man/Makefile])
+AC_OUTPUT


### PR DESCRIPTION
passing output file names to AC_CONFIG() is deprecated